### PR TITLE
Add option to ignore current page

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ enabled: true
 show_all: true
 built_in_css: true
 include_home: true
+include_current: true
 icon_home: ''
 icon_divider_classes: 'fa fa-angle-right'
 link_trailing: false

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This command will check your Grav install to see if your Breadcrumbs plugin is d
 Manually updating Breadcrumbs is pretty simple. Here is what you will need to do to get this done:
 
 * Delete the `your/site/user/plugins/breadcrumbs` directory.
-* Downalod the new version of the Breadcrumbs plugin from either [GitHub](https://github.com/getgrav/grav-plugin-breadcrumbs) or [GetGrav.org](http://getgrav.org/downloads/plugins#extras).
+* Download the new version of the Breadcrumbs plugin from either [GitHub](https://github.com/getgrav/grav-plugin-breadcrumbs) or [GetGrav.org](http://getgrav.org/downloads/plugins#extras).
 * Unzip the zip file in `your/site/user/plugins` and rename the resulting folder to `breadcrumbs`.
 * Clear the Grav cache. The simplest way to do this is by going to the root Grav directory in terminal and typing `bin/grav clear-cache`.
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -59,6 +59,17 @@ form:
       validate:
         type: bool
 
+    include_current:
+      type: toggle
+      label: Include Current Page
+      highlight: 1
+      default: 1
+      options:
+        1: Enabled
+        0: Disabled
+      validate:
+        type: bool
+
     icon_home:
       type: text
       size: medium

--- a/breadcrumbs.yaml
+++ b/breadcrumbs.yaml
@@ -2,6 +2,7 @@ enabled: true
 show_all: true
 built_in_css: true
 include_home: true
+include_current: true
 icon_home: ''
 icon_divider_classes: 'fa fa-angle-right'
 link_trailing: false

--- a/classes/breadcrumbs.php
+++ b/classes/breadcrumbs.php
@@ -44,15 +44,24 @@ class Breadcrumbs
         $grav = Grav::instance();
         $current = $grav['page'];
 
-        while ($current && !$current->root()) {
-            $hierarchy[$current->url()] = $current;
-            $current = $current->parent();
-        }
-
         // Page cannot be routed.
         if (!$current) {
             $this->breadcrumbs = array();
             return;
+        }
+
+        if (!$current->root()) {
+
+            if ($this->config['include_current']) {
+                $hierarchy[$current->url()] = $current;
+            }
+
+            $current = $current->parent();
+
+            while ($current && !$current->root()) {
+                $hierarchy[$current->url()] = $current;
+                $current = $current->parent();
+            }
         }
 
         if ($this->config['include_home']) {
@@ -61,7 +70,6 @@ class Breadcrumbs
                 $hierarchy[] = $home;
             }
         }
-
 
         $this->breadcrumbs = array_reverse($hierarchy);
     }


### PR DESCRIPTION
Addresses issue #10 

- adds a new option to ignore the current page
- adjusts the logic of the breadcrumbs `build()` function to enable new option
- updates readme documentation