### PR TITLE
Improve html semantics and accessibility

### DIFF
--- a/css/breadcrumbs.css
+++ b/css/breadcrumbs.css
@@ -3,16 +3,20 @@
     line-height: 3rem;
     padding-left: 3rem;
 }
-#breadcrumbs span {
-    display: inline-block;
-    padding: 0 1rem;
+#breadcrumbs ol {
+    list-style: none;
+    margin: 0;
 }
-#breadcrumbs span:first-child {
-    padding-left: 0;
+#breadcrumbs li {
+    display: inline-block;
 }
 #breadcrumbs i {
     display: inline-block;
     width: 20px;
     text-align: center;
+}
+#breadcrumbs li i {
+    margin-left: 1rem;
+    margin-right: 1rem;
 }
 

--- a/templates/partials/breadcrumbs.html.twig
+++ b/templates/partials/breadcrumbs.html.twig
@@ -3,36 +3,38 @@
 {% set divider = breadcrumbs_config.icon_divider_classes %}
 
 {% if crumbs|length > 1 or breadcrumbs_config.show_all %}
-<div id="breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList">
-    {% if breadcrumbs_config.icon_home %}
-    <i class="{{ breadcrumbs_config.icon_home }}"></i>
-    {% endif %}
-    {% for crumb in crumbs %}
-    <span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-        {% if not loop.last %}
-            {% if crumb.routable %}
-                <a itemscope itemtype="http://schema.org/Thing" itemprop="item" href="{{ crumb.url }}" itemid="{{ crumb.url }}">
-                    <span itemprop="name">{{ crumb.menu }}</span>
-                </a>
-            {% else  %}
-                <span itemscope itemtype="http://schema.org/Thing" itemprop="item" itemid="{{ crumb.url }}">
-                    <span itemprop="name">{{ crumb.menu }}</span>
-                </span>
-            {% endif %}
-            <i class="{{ divider }}"></i>
-        {% else %}
-            {% if breadcrumbs_config.link_trailing %}
-                <a itemscope itemtype="http://schema.org/Thing" itemprop="item" href="{{ crumb.url }}" itemid="{{ crumb.url }}">
-                    <span itemprop="name">{{ crumb.menu }}</span>
-                </a>
-            {% else %}
-                <span itemscope itemtype="http://schema.org/Thing" itemprop="item" itemid="{{ crumb.url }}">
-                    <span itemprop="name">{{ crumb.menu }}</span>
-                </span>
-            {% endif %}
+<nav id="breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList">
+    <ol>
+        {% if breadcrumbs_config.icon_home %}
+        <i class="{{ breadcrumbs_config.icon_home }}"></i>
         {% endif %}
-        <meta itemprop="position" content="{{ loop.index }}" />
-    </span>
-    {% endfor %}
-</div>
+        {% for crumb in crumbs %}
+        <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+            {% if not loop.last %}
+                {% if crumb.routable %}
+                    <a itemscope itemtype="http://schema.org/Thing" itemprop="item" href="{{ crumb.url }}" itemid="{{ crumb.url }}">
+                        <span itemprop="name">{{ crumb.menu }}</span>
+                    </a>
+                {% else  %}
+                    <span itemscope itemtype="http://schema.org/Thing" itemprop="item" itemid="{{ crumb.url }}">
+                        <span itemprop="name">{{ crumb.menu }}</span>
+                    </span>
+                {% endif %}
+                <i class="{{ divider }}"></i>
+            {% else %}
+                {% if breadcrumbs_config.link_trailing %}
+                    <a itemscope itemtype="http://schema.org/Thing" itemprop="item" href="{{ crumb.url }}" itemid="{{ crumb.url }}" aria-current="page">
+                        <span itemprop="name">{{ crumb.menu }}</span>
+                    </a>
+                {% else %}
+                    <span itemscope itemtype="http://schema.org/Thing" itemprop="item" itemid="{{ crumb.url }}">
+                        <span itemprop="name">{{ crumb.menu }}</span>
+                    </span>
+                {% endif %}
+            {% endif %}
+            <meta itemprop="position" content="{{ loop.index }}" />
+        </li>
+        {% endfor %}
+    </ol>
+</nav>
 {% endif %}


### PR DESCRIPTION
This PR aims to improve the breadcrumbs' markup and their use with screenreaders.

The previous markup with `divs` and `spans` is replaced by a semantic `nav` element with an ordered list of links:
```html
<nav>
  <ol>
    <li><a href="/">Home</a></li>
    <li><a href="/plugins">Plugins</a></li>
    <li>Breadcrumbs</li>
  </ol>
</nav>
```

In case the current page is linked, the link receives an attribute of `aria-current="page"` for screenreader users:
```html
<li><a href="/plugins/breadcrumbs" aria-current="page">Breadcrumbs</a></li>
```

The schema microdata are still in place.