### PR TITLE
Support RTL by using CSS logical properties

### DIFF
--- a/css/breadcrumbs.css
+++ b/css/breadcrumbs.css
@@ -1,14 +1,14 @@
 #breadcrumbs {
     height: 3rem;
     line-height: 3rem;
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
 }
 #breadcrumbs span {
     display: inline-block;
     padding: 0 1rem;
 }
 #breadcrumbs span:first-child {
-    padding-left: 0;
+    padding-inline-start: 0;
 }
 #breadcrumbs i {
     display: inline-block;


### PR DESCRIPTION
This PR replaces two instances of `padding-left` with `padding-inline-start`, so as not to make the assumption that the breadcrumbs are in an LTR environment. 